### PR TITLE
[Bug] Correção MeuFiltro

### DIFF
--- a/MeuFiltro.php
+++ b/MeuFiltro.php
@@ -4,7 +4,7 @@ class MeuFiltro extends php_user_filter
 {
     private $previousData;
 
-    public function filter($in, $out, &$consumed, $closing)
+    public function filter($in, $out, &$consumed, $closing): int
     {
         $saida = '';
 
@@ -25,15 +25,15 @@ class MeuFiltro extends php_user_filter
                 return PSFS_FEED_ME;
             }
 
-            $linhas = explode("\n", $stringFromBucket);
+        }
+        
+        $linhas = explode("\n", $stringFromBucket ?? $this->previousData);
 
-            foreach ($linhas as $linha) {
-                if (stripos($linha, 'parte') !== false) {
-                    $saida .= "$linha\n";
-                }
+        foreach ($linhas as $linha) {
+            if (stripos($linha, 'parte') !== false) {
+                $saida .= "$linha\n";
             }
         }
-
         $bucketSaida = stream_bucket_new($this->stream, $saida);
         stream_bucket_append($out, $bucketSaida);
 


### PR DESCRIPTION
Ao clonar o repositório e tentar aplicar o Meu Filtro, o retorno estava vindo vazio. O código não estava atingindo o "explode", já que solicitava mais dados e saía do loop antes disso.

A alteração resume-se a mover o tratamento do filtro para fora do loop, incluindo um null coalesce operator para verificar se o dado está no $stringFromBucket (entrou no loop) ou se o arquivo finalizou em caracter outro que não uma quebra de linha (entra na linha 23 e seta o previousData como o texto e o próximo loop não entra, por não ter mais dados).

Testado com texto grande (8000 linhas de cópias do original), original, finalizando em quebra de linha ou não.